### PR TITLE
Replace `set-env` command with setting env variables via $GITHUB_ENV file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+- Add option to configure global git user name, email and password
+
+## [2.0.0] - 2020-10-29
+### Changed
+- Replace `set-env` command with setting env variables via $GITHUB_ENV file
+
+## [1.0.0] - 2017-06-20
+### Added
+- Add configurable user name and user email for commits created by a custom action
+- Add configurable actor and token to push updates from a custom action

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - Add option to configure global git user name, email and password
 
-## [2.0.0] - 2020-10-29
+## [v2] - 2020-11-14
 ### Changed
-- Replace `set-env` command with setting env variables via $GITHUB_ENV file
+- Replace deprecated `set-env` command with setting env variables via $GITHUB_ENV file
 
-## [1.0.0] - 2017-06-20
+## [v1] - 2020-03-06
 ### Added
 - Add configurable user name and user email for commits created by a custom action
 - Add configurable actor and token to push updates from a custom action

--- a/README.md
+++ b/README.md
@@ -24,6 +24,22 @@ You may also want to override default git user name and email.
 
 Actor would also be overridden when pushing to a repo cloud other than GitHub.
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+## Table of Contents
+
+- [Inputs](#inputs)
+- [Outputs](#outputs)
+- [Usage Example](#usage-example)
+- [Versions](#versions)
+  - [v2](#v2)
+  - [v1](#v1)
+- [License](#license)
+- [No affiliation with GitHub Inc.](#no-affiliation-with-github-inc)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+<!-- generated with [DocToc](https://github.com/thlorenz/doctoc) -->
+
 ## Inputs
 
 - `name`: value for git config user.name (default: `GitHub Action`)
@@ -74,6 +90,11 @@ Changed the way `GIT_USER` env var is being assigned.
 
 Reason:
 [GitHub deprecated `add-path` and `set-env` commands](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/).
+
+### v1
+Features:
+- Configurable user name and user email for commits created by a custom action
+- Configurable actor and token (GIT_USER) to push updates from a custom action
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ jobs:
         yarn run build
         yarn run deploy
     # publish to a branch in different repo using a PAT generated on that other repo
-    - uses: oleksiyrudenko/gha-git-credentials@v1
+    - uses: oleksiyrudenko/gha-git-credentials@v2
       with:
         name: 'Oleksiy Rudenko'
         email: 'oleksiy.rudenko@domain.com'

--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ jobs:
         yarn run deploy web-central/master
 ```
 
+## Versions
+
+Check [CHANGELOG](./CHANGELOG.md) for details.
+
+### v2
+Changed the way `GIT_USER` env var is being assigned.
+
+Reason:
+[GitHub deprecated `add-path` and `set-env` commands](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/).
+
 ## License
 
 Scripts and documentation in this project are released under the [MIT license](LICENSE).

--- a/action.sh
+++ b/action.sh
@@ -9,4 +9,4 @@ INPUT_TOKEN=${INPUT_TOKEN:-"${{ secrets.GITHUB_TOKEN }}"}
 git config user.email ${INPUT_EMAIL}
 git config user.name ${INPUT_NAME}
 git config user.password ${INPUT_TOKEN}
-echo "::set-env name=GIT_USER::${INPUT_ACTOR}:${INPUT_TOKEN}"
+echo "name=GIT_USER::${INPUT_ACTOR}:${INPUT_TOKEN}" >> $GITHUB_ENV

--- a/action.sh
+++ b/action.sh
@@ -9,4 +9,4 @@ INPUT_TOKEN=${INPUT_TOKEN:-"${{ secrets.GITHUB_TOKEN }}"}
 git config user.email ${INPUT_EMAIL}
 git config user.name ${INPUT_NAME}
 git config user.password ${INPUT_TOKEN}
-echo "name=GIT_USER::${INPUT_ACTOR}:${INPUT_TOKEN}" >> $GITHUB_ENV
+echo "GIT_USER=${INPUT_ACTOR}:${INPUT_TOKEN}" >> $GITHUB_ENV

--- a/dist/action.sh
+++ b/dist/action.sh
@@ -9,4 +9,4 @@ INPUT_TOKEN=${INPUT_TOKEN:-"${{ secrets.GITHUB_TOKEN }}"}
 git config user.email ${INPUT_EMAIL}
 git config user.name ${INPUT_NAME}
 git config user.password ${INPUT_TOKEN}
-echo "name=GIT_USER::${INPUT_ACTOR}:${INPUT_TOKEN}" >> $GITHUB_ENV
+echo "::set-env name=GIT_USER::${INPUT_ACTOR}:${INPUT_TOKEN}"

--- a/dist/action.sh
+++ b/dist/action.sh
@@ -9,4 +9,4 @@ INPUT_TOKEN=${INPUT_TOKEN:-"${{ secrets.GITHUB_TOKEN }}"}
 git config user.email ${INPUT_EMAIL}
 git config user.name ${INPUT_NAME}
 git config user.password ${INPUT_TOKEN}
-echo "::set-env name=GIT_USER::${INPUT_ACTOR}:${INPUT_TOKEN}"
+echo "name=GIT_USER::${INPUT_ACTOR}:${INPUT_TOKEN}" >> $GITHUB_ENV

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gha-git-credentials",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "A GitHub action for setting up git credentials",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Reasons:
- https://github.com/OleksiyRudenko/gha-git-credentials/pull/1#discussion_r514161984
- https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/