### PR TITLE
fix: default actor

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,9 +19,8 @@ inputs:
     required: false
     default: 'GitHub Action'
   actor:
-    description: 'GitHub Actor Username (default: github.actor)'
+    description: 'GitHub Actor Username (default: `$GITHUB_ACTOR`)'
     required: false
-    default: GITHUB_ACTOR
   token:
     description: 'GitHub Token'
     required: true


### PR DESCRIPTION
This PR is to unset the default value of `actor` input, otherwise `INPUT_ACTOR` will be always "GITHUB_ACTOR" instead of `GITHUB_ACTOR` env var if the input is omitted.