### PR TITLE
Update node version to 20 in GitHub Action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,5 +26,5 @@ inputs:
     description: 'GitHub Token'
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
**Overview**
Upgrade node version to resolve warnings about out-of-date node version.

**Problem**
The node version used [here](https://github.com/OleksiyRudenko/gha-git-credentials/blob/master/action.yml#L29) is out of date, resulting in a warning (`
download-data-json
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20:`)  when running the action.

**Solution**
Upgrade to node version 20, as suggested by the warning message. The upgrade has been tested locally by running with node version 20, and index.js continues to behave as it does when running with version 16.